### PR TITLE
Use type instead of sql_type

### DIFF
--- a/lib/simple_form/bootstrap/form_builders/date_time.rb
+++ b/lib/simple_form/bootstrap/form_builders/date_time.rb
@@ -1,18 +1,21 @@
 module SimpleForm::Bootstrap::FormBuilders::DateTime
   DATE_TIME_COLUMN_TYPES = [
+    :datetime,
     'datetime',
     'timestamp',
     'timestamp without time zone'
   ].freeze
 
   DATE_COLUMN_TYPES = [
+    :date,
     'date'
   ].freeze
 
   def default_input_type(attribute_name, column, options, *args, &block)
     if (options.is_a?(Hash) ? options[:as] : @options[:as]).nil? && !column.nil?
-      return :bootstrap_date_time if DATE_TIME_COLUMN_TYPES.include?(column.sql_type)
-      return :bootstrap_date if DATE_COLUMN_TYPES.include?(column.sql_type)
+      type = column.respond_to?(:type) ? column.type : column.sql_type
+      return :bootstrap_date_time if DATE_TIME_COLUMN_TYPES.include?(type)
+      return :bootstrap_date if DATE_COLUMN_TYPES.include?(type)
     end
 
     super(attribute_name, column, options, *args, &block)

--- a/spec/simple_form/bootstrap/form_builders/date_time_spec.rb
+++ b/spec/simple_form/bootstrap/form_builders/date_time_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'date_time', type: :view do
     end
 
     def column_for_attribute(*)
-      Struct.new(:sql_type).new(@column_sql_type)
+      Struct.new([:sql_type, :type].sample).new(@column_sql_type)
     end
 
     def has_attribute?(*)
@@ -34,7 +34,7 @@ RSpec.describe 'date_time', type: :view do
   end
 
   context 'when the database column is a datetime' do
-    let(:object) { DateTimeModel.new('datetime') }
+    let(:object) { DateTimeModel.new(['datetime', :datetime].sample) }
     it 'displays the text field' do
       expect(rendered).to have_tag('div.form-group.bootstrap_date_time') do
         with_tag('input.bootstrap_date_time', with: { value: object.test })
@@ -52,7 +52,7 @@ RSpec.describe 'date_time', type: :view do
   end
 
   context 'when the database column is a date' do
-    let(:object) { DateTimeModel.new('date') }
+    let(:object) { DateTimeModel.new(['date', :date].sample) }
     it 'displays the text field' do
       expect(rendered).to have_tag('div.form-group.bootstrap_date') do
         with_tag('input.bootstrap_date', with: { value: object.test })
@@ -62,7 +62,7 @@ RSpec.describe 'date_time', type: :view do
 
   context 'when the database column is not a datetime' do
     let(:object) { DateTimeModel.new('string') }
-    it 'does not have a  datepicker control' do
+    it 'does not have a datepicker control' do
       expect(rendered).not_to have_tag('div.form-group.bootstrap_date_time')
     end
   end

--- a/spec/simple_form/bootstrap/form_builders/date_time_spec.rb
+++ b/spec/simple_form/bootstrap/form_builders/date_time_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe 'date_time', type: :view do
     end
 
     def column_for_attribute(*)
-      Struct.new([:sql_type, :type].sample).new(@column_sql_type)
+      if @column_sql_type.is_a?(Symbol)
+        Struct.new(:type).new(@column_sql_type)
+      else
+        Struct.new(:sql_type).new(@column_sql_type)
+      end
     end
 
     def has_attribute?(*)
@@ -34,28 +38,32 @@ RSpec.describe 'date_time', type: :view do
   end
 
   context 'when the database column is a datetime' do
-    let(:object) { DateTimeModel.new(['datetime', :datetime].sample) }
-    it 'displays the text field' do
-      expect(rendered).to have_tag('div.form-group.bootstrap_date_time') do
-        with_tag('input.bootstrap_date_time', with: { value: object.test })
+    ['datetime', :datetime].each do |type|
+      let(:object) { DateTimeModel.new(type) }
+      it 'displays the text field' do
+        expect(rendered).to have_tag('div.form-group.bootstrap_date_time') do
+          with_tag('input.bootstrap_date_time', with: { value: object.test })
+        end
       end
-    end
 
-    it 'has a hidden datepicker control' do
-      selector = 'div.form-group.bootstrap_date_time div.input-group'
-      required_style = { style: 'display: none' }
+      it 'has a hidden datepicker control' do
+        selector = 'div.form-group.bootstrap_date_time div.input-group'
+        required_style = { style: 'display: none' }
 
-      expect(rendered).to have_tag(selector, with: required_style) do
-        with_tag('input.bootstrap_date_time', with: { type: 'hidden' })
+        expect(rendered).to have_tag(selector, with: required_style) do
+          with_tag('input.bootstrap_date_time', with: { type: 'hidden' })
+        end
       end
     end
   end
 
   context 'when the database column is a date' do
-    let(:object) { DateTimeModel.new(['date', :date].sample) }
-    it 'displays the text field' do
-      expect(rendered).to have_tag('div.form-group.bootstrap_date') do
-        with_tag('input.bootstrap_date', with: { value: object.test })
+    ['date', :date].each do |type|
+      let(:object) { DateTimeModel.new(type) }
+      it 'displays the text field' do
+        expect(rendered).to have_tag('div.form-group.bootstrap_date') do
+          with_tag('input.bootstrap_date', with: { value: object.test })
+        end
       end
     end
   end


### PR DESCRIPTION
- Support simple_form 3.3

Simple form updated their `find_attribute_column` in 3.3, sql_type is not work anymore.

```
def find_attribute_column(attribute_name)
  if @object.respond_to?(:type_for_attribute) && @object.has_attribute?(attribute_name)
    @object.type_for_attribute(attribute_name)
  elsif @object.respond_to?(:column_for_attribute) && @object.has_attribute?(attribute_name)
    @object.column_for_attribute(attribute_name)
  end
end
```

Actually, I don't know why `sql_type` is used before, @lowjoel Any comments ? 
