### PR TITLE
Various fixes for date time inputs  

### DIFF
--- a/app/assets/javascripts/simple_form-bootstrap/date_time_input.js
+++ b/app/assets/javascripts/simple_form-bootstrap/date_time_input.js
@@ -62,14 +62,14 @@
   $.fn.datetimepicker.defaults = oldDateTimePicker.defaults;
 
   // Ensure that the dates are properly formatted in the text field.
-  $(document).on('dp.change dp.show', '.bootstrap-datepicker:' +
+  $(document).on('dp.change', '.bootstrap-datepicker:' +
   'not(.bootstrap-timepicker)', function (e) {
     var date = e.date;
     var rails_date_format = date.format(DATE_FORMAT);
     $(this).next('input[type=hidden]').val(rails_date_format);
   });
 
-  $(document).on('dp.change dp.show', '.bootstrap-timepicker', function (e) {
+  $(document).on('dp.change', '.bootstrap-timepicker', function (e) {
     var date = e.date;
     var rails_date_format = date.format(DATETIME_FORMAT);
     $(this).next('input[type=hidden]').val(rails_date_format);

--- a/app/assets/javascripts/simple_form-bootstrap/date_time_input.js
+++ b/app/assets/javascripts/simple_form-bootstrap/date_time_input.js
@@ -65,13 +65,19 @@
   $(document).on('dp.change', '.bootstrap-datepicker:' +
   'not(.bootstrap-timepicker)', function (e) {
     var date = e.date;
-    var rails_date_format = date.format(DATE_FORMAT);
+    var rails_date_format = '';
+    if (date) {
+      rails_date_format = date.format(DATE_FORMAT);
+    }
     $(this).next('input[type=hidden]').val(rails_date_format);
   });
 
   $(document).on('dp.change', '.bootstrap-timepicker', function (e) {
     var date = e.date;
-    var rails_date_format = date.format(DATETIME_FORMAT);
+    var rails_date_format = '';
+    if (date) {
+      rails_date_format = date.format(DATETIME_FORMAT);
+    }
     $(this).next('input[type=hidden]').val(rails_date_format);
   });
 }(jQuery));


### PR DESCRIPTION
I get `TypeError: undefined is not an object (evaluating 'date.format')` when the date picker shows, not sure why `db.show` is also listened before, from their documentation, "show" event does not have a "date" object.

The second commit allows the deletion of the date, when the date is deleted from input, the `date` object is `false`, thus there's no `format`.